### PR TITLE
[pandas 2.0] Removing type_ and length_ members from Array base and pushing them into sub-classes and adding a signature for obtaining covariant return type for DataType 

### DIFF
--- a/pandas/native.pxd
+++ b/pandas/native.pxd
@@ -74,7 +74,7 @@ cdef extern from "pandas/api.h" namespace "pandas":
         c_bool Equals(const DataType& other)
         string ToString()
 
-    ctypedef shared_ptr[DataType] TypePtr
+    ctypedef shared_ptr[const DataType] TypePtr
 
     cdef cppclass Int8Type(DataType):
         pass

--- a/pandas/native.pyx
+++ b/pandas/native.pyx
@@ -277,7 +277,7 @@ cdef Array wrap_array(const lp.ArrayPtr& arr):
 
 cdef PandasType wrap_type(const lp.TypePtr& sp_type):
     cdef:
-        lp.DataType* type = sp_type.get()
+        const lp.DataType* type = sp_type.get()
         PandasType result
 
     if type.type() == lp.TypeId_CATEGORY:

--- a/src/pandas/array.cc
+++ b/src/pandas/array.cc
@@ -11,11 +11,8 @@ namespace pandas {
 // ----------------------------------------------------------------------
 // Array
 
-Array::Array(const std::shared_ptr<DataType>& type, int64_t length)
-    : type_(type), length_(length) {}
-
 Status Array::Copy(std::shared_ptr<Array>* out) const {
-  return Copy(0, length_, out);
+  return Copy(0, length(), out);
 }
 
 // ----------------------------------------------------------------------

--- a/src/pandas/type.cc
+++ b/src/pandas/type.cc
@@ -41,4 +41,7 @@ constexpr const char* FloatType::NAME;
 constexpr const char* DoubleType::NAME;
 constexpr const char* BooleanType::NAME;
 
+std::shared_ptr<PyObjectType> PyObjectType::SINGLETON =
+        std::move(std::make_shared<PyObjectType>());
+
 }  // namespace pandas

--- a/src/pandas/type.h
+++ b/src/pandas/type.h
@@ -57,7 +57,7 @@ class DataType {
 
   virtual std::string ToString() const = 0;
 
-  virtual bool Equals(const DataType& other) { return type_ == other.type_; }
+  virtual bool Equals(const DataType& other) const { return type_ == other.type_; }
 
   TypeId type() const { return type_; }
 
@@ -65,7 +65,7 @@ class DataType {
   TypeId type_;
 };
 
-typedef std::shared_ptr<DataType> TypePtr;
+using TypePtr = std::shared_ptr<const DataType>;
 
 class PANDAS_EXPORT TimestampType : public DataType {
  public:
@@ -92,6 +92,8 @@ class PANDAS_EXPORT PyObjectType : public DataType {
   static char const* name() { return "object"; }
 
   std::string ToString() const override;
+
+  static std::shared_ptr<PyObjectType> SINGLETON;
 };
 
 template <typename DERIVED, typename C_TYPE, DataType::TypeId TYPE_ID,

--- a/src/pandas/types/category.cc
+++ b/src/pandas/types/category.cc
@@ -5,6 +5,10 @@
 
 namespace pandas {
 
+CategoryArray::CategoryArray(const std::shared_ptr<CategoryType>& type,
+    const std::shared_ptr<Array>& codes)
+    : Array(codes->length(), 0), codes_(codes), type_(type) {}
+
 std::string CategoryType::ToString() const {
   std::stringstream s;
   s << "category<" << category_type()->ToString() << ">";

--- a/src/pandas/types/category.h
+++ b/src/pandas/types/category.h
@@ -15,29 +15,31 @@
 namespace pandas {
 
 struct CategoryType : public DataType {
-  explicit CategoryType(const ArrayView& categories)
+  explicit CategoryType(const std::shared_ptr<Array>& categories)
       : DataType(DataType::CATEGORY), categories_(categories) {}
 
   std::string ToString() const override;
 
-  std::shared_ptr<DataType> category_type() const { return categories_.data()->type(); }
+  std::shared_ptr<const DataType> category_type() const {
+    return categories_->type();
+  }
 
-  const ArrayView& categories() const { return categories_; }
+  std::shared_ptr<Array> categories() const { return categories_; }
 
  protected:
-  ArrayView categories_;
+  std::shared_ptr<Array> categories_;
 };
 
 class CategoryArray : public Array {
  public:
-  const ArrayView& codes() const { return codes_; }
+  CategoryArray(const std::shared_ptr<CategoryType>& type, const std::shared_ptr<Array>& codes);
 
-  const ArrayView& categories() const {
-    return static_cast<CategoryType*>(type_.get())->categories();
-  }
+  std::shared_ptr<Array> codes() const { return codes_; }
+  std::shared_ptr<Array> categories() const { return type_->categories(); }
 
  private:
-  ArrayView codes_;
+  std::shared_ptr<Array> codes_;
+  std::shared_ptr<CategoryType> type_;
 };
 
 }  // namespace pandas

--- a/src/pandas/types/numeric.cc
+++ b/src/pandas/types/numeric.cc
@@ -21,9 +21,9 @@ namespace pandas {
 // Generic numeric class
 
 template <typename TYPE>
-NumericArray<TYPE>::NumericArray(const std::shared_ptr<DataType>& type, int64_t length,
-    const std::shared_ptr<Buffer>& data)
-    : Array(type, length), data_(data) {}
+NumericArray<TYPE>::NumericArray(const DataTypePtr& type, int64_t length,
+    const std::shared_ptr<Buffer>& data, const std::shared_ptr<Buffer>& valid_bits)
+    : Array(length, 0), type_(type), data_(data), valid_bits_(valid_bits) {}
 
 template <typename TYPE>
 auto NumericArray<TYPE>::data() const -> const T* {
@@ -41,12 +41,17 @@ std::shared_ptr<Buffer> NumericArray<TYPE>::data_buffer() const {
   return data_;
 }
 
+template <typename TYPE>
+TypePtr NumericArray<TYPE>::type() const {
+  return type_;
+}
+
 // ----------------------------------------------------------------------
 // Floating point class
 
 template <typename TYPE>
 FloatingArray<TYPE>::FloatingArray(int64_t length, const std::shared_ptr<Buffer>& data)
-    : NumericArray<TYPE>(TYPE::SINGLETON, length, data) {}
+    : NumericArray<TYPE>(TYPE::SINGLETON, length, data, nullptr) {}
 
 template <typename TYPE>
 int64_t FloatingArray<TYPE>::GetNullCount() {
@@ -92,7 +97,7 @@ IntegerArray<TYPE>::IntegerArray(int64_t length, const std::shared_ptr<Buffer>& 
 template <typename TYPE>
 IntegerArray<TYPE>::IntegerArray(int64_t length, const std::shared_ptr<Buffer>& data,
     const std::shared_ptr<Buffer>& valid_bits)
-    : NumericArray<TYPE>(TYPE::SINGLETON, length, data), valid_bits_(valid_bits) {}
+    : NumericArray<TYPE>(TYPE::SINGLETON, length, data, valid_bits) {}
 
 template <typename TYPE>
 int64_t IntegerArray<TYPE>::GetNullCount() {
@@ -185,6 +190,7 @@ template class IntegerArray<Int32Type>;
 template class IntegerArray<UInt64Type>;
 template class IntegerArray<Int64Type>;
 
+template class NumericArray<BooleanType>;
 template class NumericArray<FloatType>;
 template class NumericArray<DoubleType>;
 template class FloatingArray<FloatType>;
@@ -195,7 +201,7 @@ template class FloatingArray<DoubleType>;
 
 BooleanArray::BooleanArray(int64_t length, const std::shared_ptr<Buffer>& data,
     const std::shared_ptr<Buffer>& valid_bits)
-    : UInt8Array(length, data, valid_bits) {
+    : IntegerArray<BooleanType>(length, data, valid_bits) {
   type_ = BooleanType::SINGLETON;
 }
 

--- a/src/pandas/types/pyobject.cc
+++ b/src/pandas/types/pyobject.cc
@@ -12,7 +12,8 @@ namespace pandas {
 
 PyObjectArray::PyObjectArray(int64_t length, const std::shared_ptr<Buffer>& data,
     const std::shared_ptr<Buffer>& valid_bits)
-    : Array(get_type_singleton<PyObjectType>(), length),
+    : Array(length, 0),
+      type_(PyObjectType::SINGLETON),
       data_(data),
       valid_bits_(valid_bits) {}
 
@@ -57,6 +58,14 @@ PyObject** PyObjectArray::data() const {
 PyObject** PyObjectArray::mutable_data() const {
   // const PyObject** is unpleasant to work with
   return reinterpret_cast<PyObject**>(const_cast<uint8_t*>(data_->data()));
+}
+
+TypePtr PyObjectArray::type() const {
+  return type_;
+}
+
+const PyObjectType& PyObjectArray::type_reference() const {
+  return *type_;
 }
 
 }  // namespace pandas

--- a/src/pandas/types/pyobject.h
+++ b/src/pandas/types/pyobject.h
@@ -30,7 +30,11 @@ class PANDAS_EXPORT PyObjectArray : public Array {
   PyObject** data() const;
   PyObject** mutable_data() const;
 
+  TypePtr type() const override;
+  const PyObjectType& type_reference() const override;
+
  protected:
+  std::shared_ptr<PyObjectType> type_;
   std::shared_ptr<Buffer> data_;
   std::shared_ptr<Buffer> valid_bits_;
 };


### PR DESCRIPTION
- Removing the DataType as a member of the Array class and adding a
  new virtual to Array named type_reference that makes it possible for
  Array sub-classes to have a covariant return type for the DataType
- Removing the length_ member from Array since is doesn't make sense
  for sub-classes such as CategoryArray, since it can obtain its
  length from its codes array. This changes the length function to
  a virtual.
- Changed the signature of Array::type to return a shared_ptr to
  a const DataType instead of a non-const DataType
- Add shared_ptr<const DataType> members to Array sub-classes that
  are the expected concrete types: CategoryType, NumericType, etc.
